### PR TITLE
Fix tests: latexrun_args should not be mutated directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+*Since latexrun is currently unmaintained, this is a fork incorporating some
+bug fixes I've found useful.*
+
 See LaTeX run.  Run latexrun.
 
 latexrun fits LaTeX into a modern build environment.  It hides LaTeX's

--- a/latexrun
+++ b/latexrun
@@ -1629,7 +1629,7 @@ class BibTeX(Task):
 
         if self.__is_biber():
             outbase = os.path.join(cwd, outbase)
-        outputs = [outbase+ext for ext in ['.bbl','.blg','.bcf']]
+        outputs = [outbase + ext for ext in ['.bbl','.blg','.bcf']]
         return RunResult(outputs, {'outbase': outbase, 'status': status,
                                    'inputs': inputs})
 

--- a/test/T-nooutput.sh
+++ b/test/T-nooutput.sh
@@ -3,17 +3,17 @@ set -e
 
 # Test running just latexrun empty.tex, where empty.tex produces no output.
 
-TMP=tmp.$(basename -s .sh $0)
-mkdir -p $TMP
-cat > $TMP/empty.tex <<EOF
+TMP=tmp.$(basename -s .sh "$0")
+mkdir -p "$TMP"
+cat > "$TMP/empty.tex" <<EOF
 \documentclass{article}
 \begin{document}
 \end{document}
 EOF
-function clean() {
-    rm -rf $TMP
+clean() {
+    rm -rf "$TMP"
 }
-trap clean SIGINT SIGTERM
+trap clean INT TERM
 
 # Intentionally use just the latexrun command to test when -o is not provided.
 "$1" "$TMP/empty.tex"

--- a/test/run
+++ b/test/run
@@ -72,7 +72,7 @@ def test(latexrun_path, latexrun_args, input_path):
     m = re.search(pre + 'bibtex-cmd: (.*)', input_src, re.I|re.M)
     if m:
         bibtex_cmd = m.group(1)
-        latexrun_args += ["--bibtex-cmd",  bibtex_cmd]
+        latexrun_args = latexrun_args + ["--bibtex-cmd",  bibtex_cmd]
 
     m = re.search(pre + 'output:\n((?:' + pre + '.*\n)*)', input_src, re.I|re.M)
     if m:


### PR DESCRIPTION
`latexrun_args` is kept between tests, therefore it should not be mutated.
Running `./runall` failed because of that for me.