### PR TITLE
correctly parse nested braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*Added fixes from various other peoples pull requests.*
+
 See LaTeX run.  Run latexrun.
 
 latexrun fits LaTeX into a modern build environment.  It hides LaTeX's

--- a/latexrun
+++ b/latexrun
@@ -230,6 +230,18 @@ def mkdir_p(path):
             pass
         else: raise
 
+def nested_parenthesis_end(string, opening, closing):
+    """Return index where closing character corresponds to opening character"""
+    stack = []
+    for i, c in enumerate(string):
+        if c == opening:
+            stack.append(i)
+        elif c == closing and stack:
+            start = stack.pop()
+            if not stack:
+                return i
+    return -1
+
 class DB:
     """A latexrun control database."""
 
@@ -1276,12 +1288,11 @@ class LaTeXFilter:
         elif ch == '{':
             # TeX uses this for various things we want to ignore, like
             # file names and print_mark.  Consume up to the '}'
-            epos = self.__data.find('}', self.__pos)
-            if epos != -1:
-                self.__pos = epos + 1
-            else:
+            epos = nested_parenthesis_end(self.__data[self.__pos-1:], '{', '}')
+            if epos == -1:
                 self.__message('warning', None,
                                "unbalanced `{' in log; file names may be wrong")
+            self.__pos += epos + 1
         elif ch == '}':
             self.__message('warning', None,
                            "extra `}' in log; file names may be wrong")

--- a/latexrun
+++ b/latexrun
@@ -79,7 +79,7 @@ def main():
         action=ArgParserWarnAction, dest='nowarns', default=set(['underfull']),
         help='Enable/disable warning from CLASS, which can be any package name, '
         'LaTeX warning class (e.g., font), bad box type '
-        '(underfull, overfull, loose, tight), or "all"')
+        '(underfull, overfull, loose, tight), strict parsing (strict-parse),  or "all"')
     arg_parser.add_argument(
         '-O', metavar='DIR', dest='obj_dir', default='latex.out',
         help='Directory for intermediate files and control database '
@@ -230,14 +230,17 @@ def mkdir_p(path):
             pass
         else: raise
 
-def nested_parenthesis_end(string, opening, closing):
+def nested_parenthesis_end(string, opening, closing, lax_checking=False):
     """Return index where closing character corresponds to opening character"""
     stack = []
     for i, c in enumerate(string):
-        if c == opening:
-            stack.append(i)
-        elif c == closing and stack:
-            start = stack.pop()
+        if c in opening:
+            stack.append(c)
+        elif c in closing and stack:
+            start_ch = stack.pop()
+            if not lax_checking and opening.index(start_ch) != closing.index(c):
+                # Mismatch, e.g. expected ')', found '}'
+                return -1
             if not stack:
                 return i
     return -1
@@ -1288,7 +1291,9 @@ class LaTeXFilter:
         elif ch == '{':
             # TeX uses this for various things we want to ignore, like
             # file names and print_mark.  Consume up to the '}'
-            epos = nested_parenthesis_end(self.__data[self.__pos-1:], '{', '}')
+            lax_checking = "strict-parse" in self.__suppress
+            epos = nested_parenthesis_end(self.__data[self.__pos-1:], '{[(', '}])',
+                                          lax_checking=lax_checking)
             if epos == -1:
                 self.__message('warning', None,
                                "unbalanced `{' in log; file names may be wrong")

--- a/latexrun
+++ b/latexrun
@@ -1284,7 +1284,7 @@ class LaTeXFilter:
                 self.__file_stack.pop()
             else:
                 self.__message('warning', None,
-                               "extra `)' in log; file names may be wrong ")
+                               "extra `)' in log; file names may be wrong")
         elif ch == '{':
             # TeX uses this for various things we want to ignore, like
             # file names and print_mark.  Consume up to the '}'

--- a/latexrun
+++ b/latexrun
@@ -1297,7 +1297,8 @@ class LaTeXFilter:
             if epos == -1:
                 self.__message('warning', None,
                                "unbalanced `{' in log; file names may be wrong")
-            self.__pos += epos + 1
+            else:
+                self.__pos += epos
         elif ch == '}':
             self.__message('warning', None,
                            "extra `}' in log; file names may be wrong")

--- a/latexrun
+++ b/latexrun
@@ -1439,14 +1439,15 @@ class LaTeXFilter:
                 return
         # Back up to the end of the known message text
         self.__pos = origpos + m.end()
-        if self.__lookingat('\n'):
+        if self.__lookingatre(r'\s*\n'):
             # We have a newline, so consume it and look for the
             # offending text.
             self.__pos += 1
             # If there is offending text, it will start with a font
             # name, which will start with a \.
-            if 'hbox' in msg and self.__lookingat('\\'):
-                self.__consume_line(unwrap=True)
+            if 'hbox' in msg and self.__lookingatre(r'(\[\]\s?)*\s*\\'):
+                consumed = self.__consume_line(unwrap=True)
+                if self.TRACE: print('consuming `<{}>\''.format(consumed))
         msg = self.__simplify_message(msg) + ' (page {})'.format(self.__pageno)
         cls = msg.split(None, 1)[0].lower()
         self.__message('warning', lineno, msg, cls=cls)

--- a/latexrun
+++ b/latexrun
@@ -861,14 +861,15 @@ class LaTeX(Task):
         pages of output.
         """
         jobname = outname = None
-        for m in re.finditer(r'^Transcript written on "?(.*)\.log"?\.$', stdout,
+        input = stdout.replace('\n', '')
+        for m in re.finditer(r'Transcript written on "?(.*)\.log"?\.', input,
                              re.MULTILINE | re.DOTALL):
             jobname = m.group(1).replace('\n', '')
         if jobname is None:
             print(stdout, file=sys.stderr)
             raise TaskError('failed to extract job name from latex log')
-        for m in re.finditer(r'^Output written on "?(.*\.[^ ."]+)"? \([0-9]+ page',
-                             stdout, re.MULTILINE | re.DOTALL):
+        for m in re.finditer(r'Output written on "?(.*\.[^ ."]+)"? \([0-9]+ page',
+                             input, re.MULTILINE | re.DOTALL):
             outname = m.group(1).replace('\n', '')
         if outname is None and not \
            re.search(r'^No pages of output\.$|^! Emergency stop\.$'

--- a/latexrun
+++ b/latexrun
@@ -875,20 +875,20 @@ class LaTeX(Task):
         really early.  The output name may be None if there were no
         pages of output.
         """
+        stdout = stdout.replace('\n', '').replace('\r', '')
         jobname = outname = None
-        input = stdout.replace('\n', '')
-        for m in re.finditer(r'Transcript written on "?(.*)\.log"?\.', input,
+        for m in re.finditer(r'Transcript written on "?(.*)\.log"?\.', stdout,
                              re.MULTILINE | re.DOTALL):
             jobname = m.group(1).replace('\n', '')
         if jobname is None:
             print(stdout, file=sys.stderr)
             raise TaskError('failed to extract job name from latex log')
-        for m in re.finditer(r'Output written on "?(.*\.[^ ."]+)"? \([0-9]+ page',
-                             input, re.MULTILINE | re.DOTALL):
+        for m in re.finditer(r'Output written on "?(.*\.[^ ."]+)"?\s+\([0-9]+ page',
+                             stdout, re.MULTILINE | re.DOTALL):
             outname = m.group(1).replace('\n', '')
         if outname is None and not \
-           re.search(r'^No pages of output\.$|^! Emergency stop\.$'
-                     r'|^!  ==> Fatal error occurred, no output PDF file produced!$',
+           re.search(r'No pages of output\.$|^! Emergency stop\.'
+                     r'|!  ==> Fatal error occurred, no output PDF file produced!',
                      stdout, re.MULTILINE):
             print(stdout, file=sys.stderr)
             raise TaskError('failed to extract output name from latex log')

--- a/test/T-mismatched-brace.tex
+++ b/test/T-mismatched-brace.tex
@@ -1,0 +1,16 @@
+% Test mismatched braces parsing warning.
+
+\documentclass{article}
+
+\begin{document}
+
+    \typeout{Error \{ foo bar }
+
+    baz.
+
+\end{document}
+
+%% status: 0
+
+%% output:
+%% T-mismatched-brace.tex: warning: unbalanced `{' in log; file names may be wrong

--- a/test/T-mismatched-brace2.tex
+++ b/test/T-mismatched-brace2.tex
@@ -1,0 +1,19 @@
+% Test mismatched braces parsing warning.
+
+\documentclass{article}
+
+\begin{document}
+
+    \typeout{Error \{ foo bar ) \} }
+
+    baz.
+
+\end{document}
+
+%% status: 0
+
+%% output:
+%% T-mismatched-brace2.tex: warning: unbalanced `{' in log; file names may be wrong
+%% T-mismatched-brace2.tex: warning: extra `}' in log; file names may be wrong
+%% T-mismatched-brace2.tex: warning: extra `)' in log; file names may be wrong
+

--- a/test/run
+++ b/test/run
@@ -94,7 +94,7 @@ def test(latexrun_path, latexrun_args, input_path):
     if input_path.endswith('.tex'):
         cmd = latexrun_cmd + [os.path.basename(input_path)]
     elif input_path.endswith('.sh'):
-        cmd = ['sh', os.path.basename(input_path)] + latexrun_cmd
+        cmd = ['bash', os.path.basename(input_path)] + latexrun_cmd
 
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                          cwd=input_dir or None)


### PR DESCRIPTION
`latexrun_args` is kept between tests, therefore it should not be mutated.
Running `./runall` failed because of that for me.